### PR TITLE
fix: changing property from id to key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ module "lambda_function" {
 
   s3_existing_package = var.s3 != null ? {
     bucket = local.s3_bucket.id
-    key    = local.s3_object.id
+    key    = local.s3_object.key
   } : null
 
   image_uri = var.ecr != null ? data.aws_ecr_image.this[var.ecr.repository].image_uri : null


### PR DESCRIPTION
A Hashicorp mudou como você acessa a chave de um objeto dentro de um s3, o ID que antes retornava somente a chave do objeto agora retorna `<nome_do_bucket>/{chave_do_objeto}` e nós estavamos usando o `id` para encontrar o .zip que armazena o código da lambda

Quebrava na criação da função Lambda

<img width="930" height="226" alt="swappy-20260427_194709" src="https://github.com/user-attachments/assets/feb2600f-4ea6-4e06-9ece-9f161938d952" />

Mudou isso na versão 6.2.0 aparentemente

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.2.0

E eu tenho 4 horas a menos de vida por causa disso
